### PR TITLE
Add Dashboard UI prototype with Chart.js, styles, and design spec

### DIFF
--- a/DEPLOYMENT_OPTIONS_UZ.md
+++ b/DEPLOYMENT_OPTIONS_UZ.md
@@ -1,0 +1,121 @@
+# Dashboard loyihasini local va free hostingda productionga chiqarish
+
+Ushbu loyiha static (`HTML/CSS/JS`) bo‘lgani uchun eng qulay yo‘l — **Git-based auto deploy**.
+
+## Qisqa tavsiya (eng mos variantlar)
+1. **Cloudflare Pages** — static loyiha uchun juda qulay, tez deploy, PR preview, custom domain.
+2. **Vercel** — Git push bilan avtomatik deploy + preview URL, juda oson DX.
+3. **Netlify** — boshlash oson, UI va deploy flow sodda.
+4. **GitHub Pages** — eng oddiy va bepul variant, docs/portfolio uchun zo‘r.
+
+---
+
+## 1) Cloudflare Pages (TAVSIYA #1)
+### Qachon tanlash kerak?
+- Sizga CDN tezligi, oddiy sozlash, branch preview va keyinroq edge/function qo‘shish kerak bo‘lsa.
+
+### Deploy qadamlar
+1. Repo’ni GitHub’ga push qiling.
+2. Cloudflare Dashboard → **Workers & Pages** → **Create application** → **Pages** → **Connect to Git**.
+3. Reponi tanlang.
+4. Build sozlamalari:
+   - **Production branch**: `main`
+   - **Build command**: `exit 0` (static uchun)
+   - **Build output directory**: `.`
+5. Deploy tugmasini bosing.
+
+### Muhim eslatma
+- `index.html` root’da bo‘lishi kerak, aks holda `404` chiqishi mumkin.
+
+---
+
+## 2) Vercel (TAVSIYA #2)
+### Qachon tanlash kerak?
+- Tez onboarding, yaxshi preview/deployment UX va keyinchalik full-stackga o‘tish rejangiz bo‘lsa.
+
+### Deploy qadamlar
+1. Vercel’da **New Project** bosing.
+2. GitHub repo’ni import qiling.
+3. Framework presetni `Other`/`No Framework` qoldiring (yoki auto detect).
+4. Kerak bo‘lsa output/root sozlang (`.`).
+5. Deploy qiling — har `push`da avtomatik deploy ishlaydi.
+
+### CLI bilan
+```bash
+npm i -g vercel
+vercel
+vercel --prod
+```
+
+---
+
+## 3) Netlify (TAVSIYA #3)
+### Qachon tanlash kerak?
+- Soddalik, forms/functions ekotizimi va oson branch deploy kerak bo‘lsa.
+
+### Deploy qadamlar
+1. Netlify → **Add new site** → **Import an existing project**.
+2. GitHub repo’ni ulang.
+3. Build command bo‘sh qoldiring (yoki kerak bo‘lsa), publish directory: `.`
+4. Deploy.
+
+### Optional: `netlify.toml`
+```toml
+[build]
+  publish = "."
+```
+
+---
+
+## 4) GitHub Pages (TAVSIYA #4)
+### Qachon tanlash kerak?
+- Eng minimal va toza static hosting xohlasangiz.
+
+### Deploy qadamlar
+1. GitHub repo → **Settings** → **Pages**.
+2. **Source**: *Deploy from a branch*.
+3. Branch: `main`, folder: `/ (root)`.
+4. Save va 5–10 daqiqa kuting.
+
+---
+
+## Local “production-like” ishga tushirish
+
+## Variant A: oddiy local server
+```bash
+python3 -m http.server 8000
+# http://localhost:8000/dashboard.html
+```
+
+## Variant B: Docker + Nginx (productionga yaqin)
+`Dockerfile`:
+```dockerfile
+FROM nginx:alpine
+COPY . /usr/share/nginx/html
+EXPOSE 80
+```
+
+Run:
+```bash
+docker build -t dashboard-ui .
+docker run -p 8080:80 dashboard-ui
+# http://localhost:8080/dashboard.html
+```
+
+---
+
+## Men uchun eng qulay integratsiya (amaliy tavsiya)
+Agar shu loyiha sizda tez-tez yangilanib turadigan bo‘lsa:
+- **1-tanlov:** Cloudflare Pages (GitHub bilan)
+- **2-tanlov:** Vercel (GitHub bilan)
+
+Sabab: ikkalasida ham `git push -> auto deploy -> preview` juda silliq ishlaydi.
+
+---
+
+## Tez checklist (production oldidan)
+- `index.html` root’da bor.
+- Relative asset path’lar to‘g‘ri (`dashboard.css`, `dashboard.js`).
+- `main` branch protected (ixtiyoriy).
+- Custom domain + HTTPS yoqilgan.
+- 404 fallback kerak bo‘lsa `404.html` qo‘shilgan.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:alpine
+COPY . /usr/share/nginx/html
+EXPOSE 80

--- a/ENVIRONMENT_RECOMMENDATION_UZ.md
+++ b/ENVIRONMENT_RECOMMENDATION_UZ.md
@@ -1,0 +1,41 @@
+# Loyihani vizual ko'rish uchun tavsiya etilgan muhitlar
+
+## Eng qulay (men tavsiya qilaman)
+### 1) VS Code + Live Server
+Nega:
+- Bir marta klik bilan browserda ochiladi.
+- Har safar fayl saqlanganda sahifa auto-refresh bo'ladi.
+- Dizayn iteratsiyasi uchun eng tez yo'l.
+
+Qadamlar:
+1. VS Code oching.
+2. `Live Server` extension o'rnating.
+3. `dashboard.html` ni ochib, `Go Live` tugmasini bosing.
+4. Sahifa odatda `http://127.0.0.1:5500/dashboard.html` da ochiladi.
+
+---
+
+### 2) Terminal (dependency-siz)
+Agar extension ishlatmasangiz:
+```bash
+python3 -m http.server 8000
+```
+So'ng browserda oching:
+- `http://localhost:8000/dashboard.html`
+
+---
+
+### 3) Docker (productionga yaqin ko'rish)
+Agar deployga yaqin muhit kerak bo'lsa:
+```bash
+docker compose up --build
+```
+So'ng browserda:
+- `http://localhost:8080/dashboard.html`
+
+---
+
+## Qaysi birini tanlash kerak?
+- Tez ko'rish/dizayn ishlari: **VS Code + Live Server**
+- Noldan, qo'shimcha narsasiz: **python3 -m http.server**
+- Deployga yaqin tekshiruv: **Docker Compose**

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Dashboard UI Prototype
+
+Ushbu loyiha endi dizayn spetsifikatsiyadan tashqari **ishlaydigan UI prototip** ham beradi.
+
+## Ishga tushirish
+1. Loyihani oching.
+2. `dashboard.html` faylini browserda oching.
+   - Yoki lokal server: `python3 -m http.server 8000`
+   - So'ng `http://localhost:8000/dashboard.html`
+
+## Nimalar qo'shildi
+- KPI kartalar (jami, muddatda, kechikayotgan, rad etilgan)
+- Filtrlar (hudud va xizmat turi)
+- Light/Dark rejim
+- Xizmat sifati line chart
+- Yo'nalishlar bo'yicha horizontal bar chart
+- Hududlar bo'yicha vizual bar-map
+
+## Fayllar
+- `dashboard.html` — UI struktura
+- `dashboard.css` — theme, grid, responsive stil
+- `dashboard.js` — data, filter logic, chart render
+- `dashboard_design_spec_uz.md` — to'liq UX/UI spetsifikatsiya

--- a/README.md
+++ b/README.md
@@ -16,8 +16,12 @@ Ushbu loyiha endi dizayn spetsifikatsiyadan tashqari **ishlaydigan UI prototip**
 - Yo'nalishlar bo'yicha horizontal bar chart
 - Hududlar bo'yicha vizual bar-map
 
+## Deploy yo'riqnomasi
+- `DEPLOYMENT_OPTIONS_UZ.md` faylida Cloudflare Pages, Vercel, Netlify, GitHub Pages va local production-like deploy bosqichlari berilgan.
+
 ## Fayllar
 - `dashboard.html` — UI struktura
 - `dashboard.css` — theme, grid, responsive stil
 - `dashboard.js` — data, filter logic, chart render
 - `dashboard_design_spec_uz.md` — to'liq UX/UI spetsifikatsiya
+- `DEPLOYMENT_OPTIONS_UZ.md` — productionga chiqarish yo'li

--- a/README.md
+++ b/README.md
@@ -3,10 +3,22 @@
 Ushbu loyiha endi dizayn spetsifikatsiyadan tashqari **ishlaydigan UI prototip** ham beradi.
 
 ## Ishga tushirish
-1. Loyihani oching.
-2. `dashboard.html` faylini browserda oching.
-   - Yoki lokal server: `python3 -m http.server 8000`
-   - So'ng `http://localhost:8000/dashboard.html`
+### Variant A: VS Code + Live Server (tavsiya)
+1. VS Code oching.
+2. `Live Server` extension o'rnating.
+3. `dashboard.html` faylida `Go Live` ni bosing.
+
+### Variant B: Python local server
+```bash
+python3 -m http.server 8000
+```
+So'ng `http://localhost:8000/dashboard.html`.
+
+### Variant C: Docker Compose (productionga yaqin)
+```bash
+docker compose up --build
+```
+So'ng `http://localhost:8080/dashboard.html`.
 
 ## Nimalar qo'shildi
 - KPI kartalar (jami, muddatda, kechikayotgan, rad etilgan)
@@ -18,6 +30,7 @@ Ushbu loyiha endi dizayn spetsifikatsiyadan tashqari **ishlaydigan UI prototip**
 
 ## Deploy yo'riqnomasi
 - `DEPLOYMENT_OPTIONS_UZ.md` faylida Cloudflare Pages, Vercel, Netlify, GitHub Pages va local production-like deploy bosqichlari berilgan.
+- `ENVIRONMENT_RECOMMENDATION_UZ.md` faylida loyihani vizual ko'rish uchun eng qulay muhitlar jamlangan.
 
 ## Fayllar
 - `dashboard.html` — UI struktura
@@ -25,3 +38,5 @@ Ushbu loyiha endi dizayn spetsifikatsiyadan tashqari **ishlaydigan UI prototip**
 - `dashboard.js` — data, filter logic, chart render
 - `dashboard_design_spec_uz.md` — to'liq UX/UI spetsifikatsiya
 - `DEPLOYMENT_OPTIONS_UZ.md` — productionga chiqarish yo'li
+- `ENVIRONMENT_RECOMMENDATION_UZ.md` — visual ko'rish uchun muhitlar
+- `Dockerfile` va `docker-compose.yml` — production-like local run

--- a/dashboard.css
+++ b/dashboard.css
@@ -1,0 +1,96 @@
+:root {
+  --bg: #f8fafc;
+  --surface: #ffffff;
+  --text: #0f172a;
+  --muted: #64748b;
+  --border: #e2e8f0;
+  --primary: #2563eb;
+  --success: #16a34a;
+  --warning: #f59e0b;
+  --danger: #dc2626;
+}
+
+body[data-theme='dark'] {
+  --bg: #0b1220;
+  --surface: #111827;
+  --text: #e5e7eb;
+  --muted: #94a3b8;
+  --border: #334155;
+  --primary: #60a5fa;
+  --success: #22c55e;
+  --warning: #fbbf24;
+  --danger: #f87171;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  padding: 20px;
+  font-family: Inter, system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.topbar, .filters, .kpis, .grid { margin-bottom: 16px; }
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 16px;
+}
+
+.topbar { display: flex; justify-content: space-between; align-items: center; }
+.topbar h1 { margin: 0 0 4px; font-size: 20px; }
+.topbar p { margin: 0; color: var(--muted); }
+.topbar-actions { display: flex; gap: 12px; align-items: center; }
+
+.filters {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(120px, 1fr));
+  gap: 12px;
+  align-items: end;
+}
+.filters label { display: grid; gap: 6px; font-size: 14px; }
+
+input, select, .btn {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  border-radius: 8px;
+  padding: 8px 10px;
+}
+.btn { cursor: pointer; }
+.btn-ghost { background: transparent; }
+
+.grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(12, 1fr);
+}
+.kpis {
+  grid-column: 1 / -1;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(4, 1fr);
+}
+.kpi h3 { margin: 0; font-size: 14px; color: var(--muted); }
+.kpi p { margin: 8px 0 0; font-size: 30px; font-weight: 700; }
+
+.map-panel { grid-column: span 8; }
+.chart-panel { grid-column: span 4; }
+.chart-wide { grid-column: 1 / -1; }
+
+.region-bars { display: grid; gap: 8px; margin-top: 12px; }
+.region-bar { display: grid; grid-template-columns: 140px 1fr 64px; gap: 8px; align-items: center; }
+.region-bar .bar {
+  height: 10px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--primary), #93c5fd);
+}
+.muted { color: var(--muted); margin-top: 0; }
+
+@media (max-width: 960px) {
+  .filters { grid-template-columns: repeat(2, 1fr); }
+  .kpis { grid-template-columns: repeat(2, 1fr); }
+  .map-panel, .chart-panel { grid-column: 1 / -1; }
+}

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="uz">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Yagona Analitik Dashboard</title>
+    <link rel="stylesheet" href="dashboard.css" />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.umd.min.js" defer></script>
+    <script src="dashboard.js" defer></script>
+  </head>
+  <body data-theme="light">
+    <header class="topbar card">
+      <div>
+        <h1>Fuqarolar murojaatlari va davlat xizmatlari</h1>
+        <p>Yagona analitik dashboard</p>
+      </div>
+      <div class="topbar-actions">
+        <span id="lastUpdate">Yangilandi: -</span>
+        <button id="themeToggle" class="btn">🌙 Dark</button>
+      </div>
+    </header>
+
+    <section class="filters card">
+      <label>Sanadan
+        <input id="dateFrom" type="date" />
+      </label>
+      <label>Sanagacha
+        <input id="dateTo" type="date" />
+      </label>
+      <label>Hudud
+        <select id="regionFilter"></select>
+      </label>
+      <label>Xizmat turi
+        <select id="serviceFilter"></select>
+      </label>
+      <button id="resetBtn" class="btn btn-ghost">Reset</button>
+    </section>
+
+    <main class="grid">
+      <section class="kpis">
+        <article class="card kpi"><h3>Jami murojaatlar</h3><p id="kpiTotal">0</p></article>
+        <article class="card kpi"><h3>Muddatda bajarilgan</h3><p id="kpiOnTime">0</p></article>
+        <article class="card kpi"><h3>Kechikayotgan</h3><p id="kpiLate">0</p></article>
+        <article class="card kpi"><h3>Rad etilgan</h3><p id="kpiRejected">0</p></article>
+      </section>
+
+      <section class="card map-panel">
+        <h2>Murojaatlar xaritasi (vizual jadval)</h2>
+        <p class="muted">Hudud bo'yicha murojaatlar soni</p>
+        <div id="regionBars" class="region-bars"></div>
+      </section>
+
+      <section class="card chart-panel">
+        <h2>Xizmat ko'rsatish sifati trendi</h2>
+        <canvas id="ratingChart" height="140"></canvas>
+      </section>
+
+      <section class="card chart-wide">
+        <h2>Yo'nalishlar bo'yicha tahlil</h2>
+        <canvas id="categoryChart" height="120"></canvas>
+      </section>
+    </main>
+  </body>
+</html>

--- a/dashboard.js
+++ b/dashboard.js
@@ -1,0 +1,138 @@
+const rawData = [
+  { region: 'Toshkent sh.', service: 'Kommunal', total: 220, onTime: 180, late: 25, rejected: 15, rating: 4.4, month: 'Yan' },
+  { region: 'Samarqand', service: 'Adliya', total: 160, onTime: 120, late: 28, rejected: 12, rating: 4.1, month: 'Fev' },
+  { region: 'Andijon', service: 'Sog\'liq', total: 140, onTime: 105, late: 24, rejected: 11, rating: 3.9, month: 'Mar' },
+  { region: 'Farg\'ona', service: 'Ta\'lim', total: 170, onTime: 140, late: 20, rejected: 10, rating: 4.3, month: 'Apr' },
+  { region: 'Namangan', service: 'Transport', total: 110, onTime: 82, late: 18, rejected: 10, rating: 3.8, month: 'May' },
+  { region: 'Buxoro', service: 'Kommunal', total: 130, onTime: 96, late: 21, rejected: 13, rating: 4.0, month: 'Iyn' }
+];
+
+const state = { region: 'Barchasi', service: 'Barchasi' };
+
+const el = {
+  regionFilter: document.getElementById('regionFilter'),
+  serviceFilter: document.getElementById('serviceFilter'),
+  resetBtn: document.getElementById('resetBtn'),
+  themeToggle: document.getElementById('themeToggle'),
+  lastUpdate: document.getElementById('lastUpdate')
+};
+
+let ratingChart;
+let categoryChart;
+
+function uniq(list) {
+  return ['Barchasi', ...new Set(list)];
+}
+
+function filtered() {
+  return rawData.filter(d =>
+    (state.region === 'Barchasi' || d.region === state.region) &&
+    (state.service === 'Barchasi' || d.service === state.service)
+  );
+}
+
+function sum(key, rows) {
+  return rows.reduce((acc, cur) => acc + cur[key], 0);
+}
+
+function renderKpis(rows) {
+  document.getElementById('kpiTotal').textContent = sum('total', rows);
+  document.getElementById('kpiOnTime').textContent = sum('onTime', rows);
+  document.getElementById('kpiLate').textContent = sum('late', rows);
+  document.getElementById('kpiRejected').textContent = sum('rejected', rows);
+}
+
+function renderRegionBars(rows) {
+  const byRegion = {};
+  rows.forEach(r => { byRegion[r.region] = (byRegion[r.region] || 0) + r.total; });
+  const max = Math.max(...Object.values(byRegion), 1);
+  const html = Object.entries(byRegion)
+    .sort((a, b) => b[1] - a[1])
+    .map(([region, value]) => `
+      <div class="region-bar">
+        <span>${region}</span>
+        <div class="bar" style="width:${Math.round((value / max) * 100)}%"></div>
+        <strong>${value}</strong>
+      </div>
+    `).join('');
+  document.getElementById('regionBars').innerHTML = html || '<p class="muted">Ma\'lumot topilmadi.</p>';
+}
+
+function renderCharts(rows) {
+  const months = rows.map(r => r.month);
+  const ratings = rows.map(r => r.rating);
+
+  if (ratingChart) ratingChart.destroy();
+  ratingChart = new Chart(document.getElementById('ratingChart'), {
+    type: 'line',
+    data: { labels: months, datasets: [{ label: 'O\'rtacha baho', data: ratings, tension: 0.3 }] },
+    options: { responsive: true, plugins: { legend: { display: false } }, scales: { y: { min: 1, max: 5 } } }
+  });
+
+  const byService = {};
+  rows.forEach(r => { byService[r.service] = (byService[r.service] || 0) + r.total; });
+  if (categoryChart) categoryChart.destroy();
+  categoryChart = new Chart(document.getElementById('categoryChart'), {
+    type: 'bar',
+    data: {
+      labels: Object.keys(byService),
+      datasets: [{ label: 'Murojaatlar soni', data: Object.values(byService) }]
+    },
+    options: { indexAxis: 'y', plugins: { legend: { display: false } } }
+  });
+}
+
+function render() {
+  const rows = filtered();
+  renderKpis(rows);
+  renderRegionBars(rows);
+  renderCharts(rows);
+}
+
+function initFilters() {
+  uniq(rawData.map(d => d.region)).forEach(v => {
+    el.regionFilter.add(new Option(v, v));
+  });
+  uniq(rawData.map(d => d.service)).forEach(v => {
+    el.serviceFilter.add(new Option(v, v));
+  });
+
+  el.regionFilter.addEventListener('change', e => {
+    state.region = e.target.value;
+    render();
+  });
+  el.serviceFilter.addEventListener('change', e => {
+    state.service = e.target.value;
+    render();
+  });
+  el.resetBtn.addEventListener('click', () => {
+    state.region = 'Barchasi';
+    state.service = 'Barchasi';
+    el.regionFilter.value = state.region;
+    el.serviceFilter.value = state.service;
+    render();
+  });
+}
+
+function initTheme() {
+  el.themeToggle.addEventListener('click', () => {
+    const isDark = document.body.dataset.theme === 'dark';
+    document.body.dataset.theme = isDark ? 'light' : 'dark';
+    el.themeToggle.textContent = isDark ? '🌙 Dark' : '☀️ Light';
+  });
+}
+
+function initDateDefaults() {
+  const to = new Date();
+  const from = new Date();
+  from.setDate(to.getDate() - 30);
+  const fmt = d => d.toISOString().slice(0, 10);
+  document.getElementById('dateFrom').value = fmt(from);
+  document.getElementById('dateTo').value = fmt(to);
+  el.lastUpdate.textContent = `Yangilandi: ${to.toISOString().slice(0, 16).replace('T', ' ')}`;
+}
+
+initFilters();
+initTheme();
+initDateDefaults();
+render();

--- a/dashboard_design_spec_uz.md
+++ b/dashboard_design_spec_uz.md
@@ -1,0 +1,213 @@
+# Fuqarolar murojaatlari va davlat xizmatlari samaradorligi
+## Yagona analitik dashboard (1 sahifa) — UX/UI dizayn spetsifikatsiyasi
+
+## 1) Maqsad va dizayn printsiplari
+Bu dashboardning asosiy vazifasi — fuqarolar murojaatlari va davlat xizmatlari bo‘yicha KPI’larni **tez o‘qiladigan, taqqoslanadigan va boshqaruv qarori qabul qilishga tayyor** formatda ko‘rsatish.
+
+Asosiy printsiplar:
+- **Ma’lumotlar ierarxiyasi:** “holat → sabab → hudud/yo‘nalish → tafsilot” ketma-ketligi.
+- **Vizual muvozanat:** yuqori qismda KPI kartalar, markazda asosiy grafiklar, pastda chuqur tahlil.
+- **Bir sahifada qaror qabul qilish:** filtrlash, trendlar, anomal holatlar bitta oqimda.
+- **Scalable architecture:** yangi widgetlar qo‘shilganda grid va component tizimi buzilmaydi.
+
+---
+
+## 2) Sahifa arxitekturasi (12-column grid)
+**Desktop (1440px)** uchun tavsiya:
+- Container: 1320px
+- Grid: 12 ustun
+- Gutters: 24px
+- Vertical rhythm: 8px base unit
+
+### Global layout
+1. **Header (doimiy):** dashboard nomi, oxirgi yangilanish vaqti, Light/Dark toggler.
+2. **Filter panel (sticky):** sana oralig‘i, viloyat/tuman, xizmat turi, “Reset”, “Apply”.
+3. **KPI qatori (4 ta karta):** jami, muddatda bajarilgan, kechikayotgan, rad etilgan.
+4. **Asosiy analitika qatori:**
+   - Chap: Murojaatlar xaritasi (katta blok)
+   - O‘ng: Xizmat ko‘rsatish sifati trend grafigi
+5. **Pastki qator:** Yo‘nalishlar bo‘yicha tahlil (bar chart + ulush).
+6. **Footer utility:** data source, metodologiya, eksport tugmasi (CSV/PDF).
+
+---
+
+## 3) Bo‘limlar bo‘yicha dizayn yechimi
+
+## A) Murojaatlar xaritasi (Uzbekistan map)
+**Maqsad:** hududiy yuklama va muammoli nuqtalarni aniqlash.
+
+**Vizual yechim:**
+- Choropleth map (gradient: past → yuqori murojaat soni).
+- Hover tooltip: viloyat nomi, jami murojaat, 7 kunlik o‘sish %, muddatda bajarilish %.
+- Click action: o‘ng panelda “Top 3 tuman” mini-list.
+
+**Rang logikasi (Light):**
+- Neutral fon: `#F7F9FC`
+- Gradient: `#D6E4FF` → `#1D4ED8`
+- Alert overlay (anomaliya): `#DC2626` kontur
+
+**Rang logikasi (Dark):**
+- Fon: `#0B1220`
+- Gradient: `#1E3A8A` → `#60A5FA`
+- Matn: `#E5E7EB`
+
+---
+
+## B) Ijro statistikasi (KPI kartalar)
+**KPI set:**
+1. Jami murojaatlar
+2. Muddatda bajarilganlar
+3. Kechikayotganlar
+4. Rad etilganlar
+
+**Karta strukturasi:**
+- Title (12–14px)
+- Primary value (28–32px, semibold)
+- Delta badge (↑/↓ % vs oldingi davr)
+- Subtext: “tanlangan period bo‘yicha”
+
+**Rang kodlash:**
+- Bajarilgan: yashil (`#16A34A`)
+- Kechikayotgan: sariq/oranj (`#F59E0B`)
+- Rad etilgan: qizil (`#DC2626`)
+- Jami: asosiy ko‘k (`#2563EB`)
+
+**UX qoidasi:** kartani bosganda tegishli komponentlar cross-filter bo‘lsin.
+
+---
+
+## C) Xizmat ko‘rsatish statistikasi
+**Maqsad:** fuqarolar bahosi va vaqt bo‘yicha trendni ko‘rsatish.
+
+**Grafik tavsiyasi:**
+- Line chart (oylik/haftalik trend)
+- Qo‘shimcha: stacked area yoki grouped bar (baholar: 1–5)
+
+**Ko‘rsatkichlar:**
+- O‘rtacha baho (masalan: 4.2/5)
+- NPS-ga o‘xshash index (ixtiyoriy)
+- Javoblar soni (sample size) — interpretatsiya uchun shart
+
+**UX detal:**
+- Toggle: “Baho trendi / Baho taqsimoti”
+- Tooltipda absolyut son + foiz birga chiqsin.
+
+---
+
+## D) Yo‘nalishlar bo‘yicha tahlil
+**Maqsad:** eng ko‘p murojaat tushayotgan sohalarni prioritetlash.
+
+**Grafik tavsiyasi:**
+- Horizontal bar chart (Kommunal, Adliya, Sog‘liqni saqlash, Ta’lim, Transport, ...)
+- Har bar ichida: murojaatlar soni + ulushi (%).
+
+**Qo‘shimcha analitika:**
+- “Top o‘sayotgan yo‘nalish” badge
+- “Eng yuqori kechikish ulushi” belgilash (ikon + rang)
+
+---
+
+## E) Filtrlar (global)
+Majburiy filtrlar:
+- Sana oralig‘i (Date range picker)
+- Viloyat / tuman
+- Xizmat turi
+
+**Interaction qoidalari:**
+- Default: oxirgi 30 kun
+- Filter state URL’da saqlansin (shareable)
+- “Apply” bosilganda barcha chartlar sinxron yangilanadi
+- “Reset” hamma filtrlarni defaultga qaytaradi
+
+---
+
+## 4) Data hierarchy va vizual balans (amaliy qoida)
+1. **1-daraja (eng muhim):** KPI kartalar + anomaliya holatlari
+2. **2-daraja:** hududiy taqsimot (xarita) va xizmat sifati trendi
+3. **3-daraja:** yo‘nalishlar bo‘yicha drill-down
+4. **4-daraja:** metadata, source, eksport
+
+**Whitespace qoidası:**
+- Bloklar oralig‘i: 24px
+- Karta ichki padding: 16–20px
+- Yirik sektsiya oralig‘i: 32px
+
+---
+
+## 5) WCAG va accessibility talablari
+- Matn/ikon kontrasti minimum **4.5:1**
+- Katta matn (18+ px) uchun **3:1**
+- Rangga bog‘liq signalga qo‘shimcha ikon/label ishlatish
+- Font size minimum 14px (body), line-height 1.4+
+- Focus state aniq ko‘rinsin (keyboard navigation)
+- Chartlarda rangdan tashqari pattern/markerlardan foydalanish
+
+---
+
+## 6) UI Kit va component modeli (Figma)
+Tavsiya etilgan component to‘plami:
+- `Header / Topbar`
+- `Filter / DatePicker`
+- `Filter / Select`
+- `Card / KPI`
+- `Chart / Map`
+- `Chart / Line`
+- `Chart / BarHorizontal`
+- `Badge / Status`
+- `Button / Primary-Secondary-Ghost`
+- `Theme / Tokens`
+
+**Auto-layout qoidalari:**
+- Har bir karta va panel auto-layoutda bo‘lsin
+- Hug/Fill mantiq to‘g‘ri berilsin
+- Variantlar: Light/Dark, Default/Hover/Active/Disabled
+
+---
+
+## 7) Light/Dark mode tokenlar (minimal)
+
+| Token | Light | Dark |
+|---|---|---|
+| `bg.primary` | `#FFFFFF` | `#0B1220` |
+| `bg.secondary` | `#F8FAFC` | `#111827` |
+| `text.primary` | `#0F172A` | `#E5E7EB` |
+| `text.secondary` | `#475569` | `#94A3B8` |
+| `accent.info` | `#2563EB` | `#60A5FA` |
+| `accent.success` | `#16A34A` | `#22C55E` |
+| `accent.warning` | `#F59E0B` | `#FBBF24` |
+| `accent.danger` | `#DC2626` | `#F87171` |
+| `border.default` | `#E2E8F0` | `#334155` |
+
+---
+
+## 8) Scalability (kelajak uchun)
+- 12-column grid saqlanadi, yangi widgetlar 3/4/6 ustunli bloklarda qo‘shiladi.
+- Chart componentlar data contract orqali ishlaydi (`label`, `value`, `delta`, `timestamp`, `region_id`).
+- Skeleton/loading va empty/error holat komponentlari oldindan tayyorlanadi.
+- Export va scheduled report moduli keyingi bosqichga mos bo‘ladi.
+
+---
+
+## 9) Baholash mezonlari bo‘yicha moslik
+- **UX Logic:** sektsiyalar “KPI → hudud → sifat → yo‘nalish” ketma-ketligi bilan mantiqiy guruhlangan.
+- **Data Visualization:** har bo‘limga maqsadga mos chart turi tanlangan (map, line, horizontal bar, KPI).
+- **Scalability:** component-based va token-based yondashuv sabab kengaytirish oson.
+
+---
+
+## 10) 1-sahifalik wireframe (matnli)
+
+```text
+[Header: Dashboard nomi | Last update | Light/Dark]
+[Filters: Date range | Region | Service type | Reset | Apply]
+
+[KPI1: Jami] [KPI2: Muddatda] [KPI3: Kechikayotgan] [KPI4: Rad etilgan]
+
+[Map: Murojaatlar xaritasi (8 col)] [Line/Rating Trend (4 col)]
+
+[Horizontal Bar: Yo'nalishlar bo'yicha tahlil (12 col)]
+
+[Footer: Source | Methodology | Export]
+```
+
+Bu wireframe Figma’da tez prototiplash uchun minimal blueprint sifatida ishlatiladi.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  dashboard:
+    build: .
+    ports:
+      - "8080:80"
+    restart: unless-stopped


### PR DESCRIPTION
### Motivation
- Provide a working single-page UI prototype for the analytics dashboard to visualize KPIs, regional distributions and service trends beyond the static design spec.
- Ship a lightweight front-end scaffold that can be opened locally for stakeholder review and iteration without backend integration.

### Description
- Added `dashboard.html` as the single-page prototype containing filters, KPI cards, region bars, and two chart canvases wired to Chart.js.
- Added `dashboard.css` with light/dark theme tokens, a 12-column responsive grid, and styles for cards, KPIs, filters, and region bars.
- Added `dashboard.js` with sample `rawData`, filter state, rendering logic for KPIs, region bars, and charts, plus theme toggle and default 30-day date range initialization.
- Added `README.md` (Uzbek) and `dashboard_design_spec_uz.md` to document usage, design rationale, and the full UX/UI specification.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a651fb5c8321a15b71cf04825054)